### PR TITLE
bugfix to reject OB/mis-sized chunks

### DIFF
--- a/improc/segfunctions.py
+++ b/improc/segfunctions.py
@@ -387,7 +387,7 @@ def peak_filter_2(data=None, params=None):
     return np.rint(centers).astype(int)
 
 def get_bounded_chunks(data=None, peaks=None, pad=None):
-    """Do filtering and peakfinding, then some extra useful things
+    """Get bounding chunks around peaks
 
     Parameters
     ----------
@@ -409,6 +409,8 @@ def get_bounded_chunks(data=None, peaks=None, pad=None):
     for position in peaks:
         try:
             chunk = data[position[0] - pad[0]:position[0] + pad[0] + 1, position[1] - pad[1]:position[1] + pad[1] + 1, position[2] - pad[2]:position[2] + pad[2] + 1]
+            # this is failing to fail for out-of-bounds chunks, assert is a quick fix
+            assert chunk.shape == (pad[0]*2+1, pad[1]*2+1, pad[2]*2+1)
             chunks.append(chunk)
         except:
             pass


### PR DESCRIPTION
In my current working example in `bfd-core`, `get_bounded_chunks()` returns a chunk of the wrong size when a negative indexing range does not trigger an exception.

This is a minimal fix, sufficient to reject the spurious chunk and sufficient to allow the two other outstanding pull requests (wb-utils and bfd-core) to move forward.

I'll open an issue here on making a more robust chunk extraction scheme.

