### PR TITLE
remove tuple type check from gaussian3d

### DIFF
--- a/improc/segfunctions.py
+++ b/improc/segfunctions.py
@@ -144,19 +144,18 @@ def gaussian3d(im, *args):
     sigma_x = sigma_y = 6
     sigma_z = 1
     if args:
-        if isinstance(args[0],tuple):
-            if len(args[0]) == 4:
-                width_x = width_y = args[0][0]
-                width_z = args[0][2]
-                sigma_x = sigma_y = args[0][1]
-                sigma_z = args[0][3]
-            elif len(args[0]) == 6: 
-                width_x = args[0][0]
-                width_y = args[0][1]
-                width_z = args[0][4]
-                sigma_x = args[0][2]
-                sigma_y = args[0][3]
-                sigma_z = args[0][5]
+        if len(args[0]) == 4:
+            width_x = width_y = args[0][0]
+            width_z = args[0][2]
+            sigma_x = sigma_y = args[0][1]
+            sigma_z = args[0][3]
+        elif len(args[0]) == 6: 
+            width_x = args[0][0]
+            width_y = args[0][1]
+            width_z = args[0][4]
+            sigma_x = args[0][2]
+            sigma_y = args[0][3]
+            sigma_z = args[0][5]
     s = im.shape
 
 


### PR DESCRIPTION
here I'm proposing to remove `if isinstance(args[0],tuple):` from gaussian3d. 
this is in reference #34 in gcamp-extractor and #3 in neuropal_imaging. briefly, the type check doesn't accomplish anything, it just makes this code susceptible to silently ignoring gaussian parameters that are in a container other than tuple (e.g. list)

is there any reason to preserve lists @gregbubnis @Borchardt ? the only one i can think of is lists are mutable while tuples are not, but i'm not aware of any operations in our codebase that depends on mutability of the gaussian parameter object.  